### PR TITLE
Close the connection in StreamingBody.close().

### DIFF
--- a/botocore/response.py
+++ b/botocore/response.py
@@ -141,6 +141,12 @@ class StreamingBody(object):
     def close(self):
         """Close the underlying http response stream."""
         self._raw_stream.close()
+        conn = getattr(self._raw_stream, '_connection', None)
+        release_conn = getattr(self._raw_stream, 'release_conn', None)
+        if conn is not None:
+            conn.close
+            if release_conn is not None:
+                release_conn()
 
 
 def get_response(operation_model, http_response):

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 from tests import unittest
 from tests.unit import BaseResponseTest
+import mock
 import datetime
 
 from dateutil.tz import tzutc
@@ -82,10 +83,14 @@ class TestStreamWrapper(unittest.TestCase):
 
     def test_streaming_body_closes(self):
         body = six.BytesIO(b'1234567890')
+        body._connection = mock.Mock()
+        body.release_conn = mock.Mock()
         stream = response.StreamingBody(body, content_length=10)
         self.assertFalse(body.closed)
         stream.close()
         self.assertTrue(body.closed)
+        body._connection.close.assert_called_once_with()
+        body.release_conn.assert_called_once_with()
 
     def test_default_iter_behavior(self):
         body = six.BytesIO(b'a' * 2048)


### PR DESCRIPTION
If StreamingBody.close() is called and the connection is closed, boto
should also close the underlying socket if any data is buffered.

Fixes #1370